### PR TITLE
fix: Edit MemberCurriculum Entity (#4)

### DIFF
--- a/src/main/java/com/m1s/m1sserver/Model/MemberCurriculum.java
+++ b/src/main/java/com/m1s/m1sserver/Model/MemberCurriculum.java
@@ -17,7 +17,7 @@ public class MemberCurriculum {
     @Getter @Setter
     private Member member;
 
-    @OneToMany
+    @ManyToOne
     @JoinColumn(name = "curriculum_id")
     @Getter @Setter
     private Curriculum curriculum;


### PR DESCRIPTION
curriculum 외래 키 관계 OneToMany에서 ManyToOne으로 변경